### PR TITLE
Update and rename new-gpt-fix-v2.py to new-gpt-fix-v3.py

### DIFF
--- a/new-gpt-fix-v3.py
+++ b/new-gpt-fix-v3.py
@@ -3,7 +3,7 @@
 import argparse
 import os
 import torch
-from diffusers import DiffusionPipeline
+from diffusers import StableDiffusionPipeline
 import library.model_util as model_util
 
 def convert_model(args):


### PR DESCRIPTION
FREAKING GPT LEFT OUT: StableDiffusionPipeline